### PR TITLE
#11 Use repo readme for package readme

### DIFF
--- a/src/SpecFlow.Internal.Json.csproj
+++ b/src/SpecFlow.Internal.Json.csproj
@@ -14,6 +14,7 @@
     <description>A really simple C# JSON parser.</description>
     <Copyright>Copyright © SpecFlow Team</Copyright>
     <PackageTags>Json;Serialisation</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageOutputPath>./../GeneratedNugetPackages/$(Configuration)</PackageOutputPath>
 
@@ -23,6 +24,7 @@
 
   <ItemGroup>
     <None Include="../LICENSE" Pack="true" PackagePath="" />
+    <None Include="..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The repo readme should also be used for the nuget package

closes #11